### PR TITLE
Add EBI repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ subprojects {
     maven {
         url "https://oss.jfrog.org/artifactory/oss-snapshot-local"
     }
+    maven {
+        url 'http://www.ebi.ac.uk/intact/maven/nexus/content/repositories/ebi-repo/'
+    }
   }
 
   test {


### PR DESCRIPTION
whoops. I removed the EBI JARs from the `/lib` directory instead using their nexus, but I failed to include the repo location in the build file. 

